### PR TITLE
deps-js-generator fixes

### DIFF
--- a/lib/deps-js-generator.js
+++ b/lib/deps-js-generator.js
@@ -33,7 +33,7 @@ DepsJsGenerator.prototype.generate = function(modules) {
     registeredModuleSet[filename] = true;
     deps[filename] = ['', ''];
     if (module.getDirectRequires().length) {
-      deps[filename][1] = '"' + module.getDirectRequires().join('","') + '"';
+      deps[filename][1] = '"' + module.getRequiredModules().join('","') + '"';
     }
     if (module.getProvidedModules().length) {
       deps[filename][0] = '"' + module.getProvidedModules().join('","') + '"';

--- a/lib/module.js
+++ b/lib/module.js
@@ -52,37 +52,37 @@ Object.defineProperties(Module.prototype, {
   /**
    * @inheritDoc
    */
-  toString : {
-    value : function() {
+  toString: {
+    value: function() {
       return this._filename;
     },
-    enumerable : false,
-    configurable : true,
-    writable : true
+    enumerable: false,
+    configurable: true,
+    writable: true
   },
 
   /**
    * @override
    * @return {string}
    */
-  valueOf : {
-    value : function() {
+  valueOf: {
+    value: function() {
       return this._filename;
     },
-    enumerable : false,
-    configurable : true,
-    writable : true
+    enumerable: false,
+    configurable: true,
+    writable: true
   },
 
   /**
    * @return {number}
    */
-  length : {
-    get : function() {
+  length: {
+    get: function() {
       return this._dependentModules.length;
     },
-    enumerable : false,
-    configurable : false
+    enumerable: false,
+    configurable: false
   },
 
   outputPath: {
@@ -92,8 +92,8 @@ Object.defineProperties(Module.prototype, {
     set: function(outputPath) {
       this._outputPath = outputPath;
     },
-    enumerable : true,
-    configurable : true
+    enumerable: true,
+    configurable: true
   }
 });
 
@@ -117,12 +117,18 @@ Module.prototype.getDirectRequires = function() {
   for (var i = 0, len = this._directRequires.length; i < len; i++) {
     name = this._moduleRegistry.getModuleInfo(this._directRequires[i]);
     var message = util.format('The module %s\nrequired from %s\nis not exists.', this._directRequires[i], this._filename);
-    assert.ok(!!name, message);
+    assert.ok( !! name, message);
     filenames.push(name);
   }
   return filenames;
 };
 
+/**
+ * @return {Array.<string>} requiredModules
+ */
+Module.prototype.getRequiredModules = function() {
+  return this._directRequires;
+};
 
 /**
  * @return {Array.<string>} providedModules
@@ -195,7 +201,7 @@ Module.removeModule = function(moduleName) {
  * @returns {?string}
  */
 Module.getModuleInfo = function(moduleName) {
-  return _moduleMap[moduleName]? _moduleMap[moduleName] : null;
+  return _moduleMap[moduleName] ? _moduleMap[moduleName] : null;
 };
 
 


### PR DESCRIPTION
Very minor error when generating a deps.js file using the default DepsJSGenerator.  It had an off by 1 error and was using the full file path instead of the module names for required.   
