### PR TITLE
now required modules are inserted to deps file in a right way

### DIFF
--- a/lib/deps-js-generator.js
+++ b/lib/deps-js-generator.js
@@ -54,7 +54,7 @@ DepsJsGenerator.prototype.generate = function(modules, sync) {
     registeredModuleSet[filename] = true;
     deps[filename] = ['', ''];
     if (module.getDirectRequires().length) {
-      deps[filename][0] = '"' + module.getRequiredModules().join('","') + '"';
+      deps[filename][1] = '"' + module.getRequiredModules().join('","') + '"';
     }
     if (module.getProvidedModules().length) {
       deps[filename][0] = '"' + module.getProvidedModules().join('","') + '"';

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "author": "Taketoshi Aono(brn) <dobaw20@gmail.com>",
+  "author": "Alexey Nikulin and Taketoshi Aono(brn) <dobaw20@gmail.com>",
   "description": "Resolve google-closure-library dependencies.",
   "repository": {
-    "url": "git@github.com:brn/closure-deps-resolver.git"
+    "url": "git@github.com:fuerte656/closure-deps-resolver.git"
   },
   "name": "closure-deps-resolver",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": false,
   "engines": {
     "node": "*"


### PR DESCRIPTION
It looks like your code never added required modules (referred by `goog.require`) to deps file due to a small typo. It is supposed that a list of required modules is passed to `goog.addDependency` as a second argument. To do it, for each filename you have a deps array containing two items. First array is supposed to have Provided Modules and the second one - Required Modules. However you send both Provided and Required Modules to the same first element of this array:

```
deps[filename][0] = '"' + module.getRequiredModules().join('","') + '"';
...
deps[filename][0] = '"' + module.getProvidedModules().join('","') + '"';
```

As a result, when you pass it to addDependency: 

```
  for (var prop in deps) {
    code += 'goog.addDependency("' + pathUtil.relative(basedir, prop) + '", [' + deps[prop][0] + '], [' + deps[prop][1] + ']);\n';
  }
```

you pass only Provided Modules and an empty array instead of Required Modules.

The fix is very easy - just replace 0 to 1 on the line where you get the list of Required Modules like this: 

`deps[filename][1] = '"' + module.getRequiredModules().join('","') + '"';`

Now it works for me.
